### PR TITLE
#168653549 fixing colors

### DIFF
--- a/UI/css/styles.css
+++ b/UI/css/styles.css
@@ -103,6 +103,12 @@ header [button]:hover {
     color: #2c2537;
 }
 
+.about-page .header li,
+.contact-page .header li{
+    box-shadow:none;
+    border:none
+}
+
 /* HOMEPAGE */
 .index-page body {
     background: linear-gradient(to bottom, rgba(224, 221, 241, 0.842), rgba(157, 149, 194, 0.87));
@@ -577,7 +583,10 @@ p.article-text {
 .contact-page .index-up-section [button] {
     box-shadow: none;
     margin-right: 5px;
-    border: 1px solid #695c80
+}
+.about-page .index-up-section [button]:hover,
+.contact-page .index-up-section [button]:hover {
+    color : rgb(89, 111, 131)
 }
 
 .about-down-section {

--- a/UI/pages/new.html
+++ b/UI/pages/new.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <link rel="shortcut icon" type="image/png" href="../images/tw-logo1.png" />
     <link rel="stylesheet" href="../css/styles.css">
-    <title> Article - ONE is better than one - TeamWork </title>
+    <title> Create Article </title>
 </head>
 
 <body class="body">
@@ -18,7 +18,8 @@
             </div>
             <nav class="nav-links">
                 <ul>
-                    <li class="user-hdr"><a href="user home.html" button><img src="../images/user.png" alt="user"></a></li>
+                    <li class="user-hdr"><a href="user home.html" button><img src="../images/user.png" alt="user"></a>
+                    </li>
                     <li><a href="login.html" class="login-link" button>Log out</a></li>
                     <li><a href="about.html" class="about-us-link" button>About</a></li>
 
@@ -43,7 +44,8 @@
 
                     <div class="article-content">
                         <input type="text" class="article-title-edit" placeholder="Title">
-                        <textarea name="article-edit" class="article-edit" cols="50" rows="10" placeholder="Write something..."></textarea>
+                        <textarea name="article-edit" class="article-edit" cols="50" rows="10"
+                            placeholder="Write something..."></textarea>
                         <a href="user%20home.html" class="post-article" button>Post article</a>
                     </div>
                 </div>


### PR DESCRIPTION
_Title_: wrong color of buttons and title on create article page.

_Issues_
- the color of buttons on hover is not clear
- the <title> text content on create article page is wrong

_Expected_ 
- the color of buttons on hover should be clear
- the <title> text content on create article page should say **Create article**

_Instructions To Display Bug_  
- Hover on header buttons on about and contact pages they should be dark purple
- check the title in the page tab and it should say **Article -ONE IS BETTER THAN ONE** instead of **Create article**

Branch Name
bg-fix-colors-168653549